### PR TITLE
NGINX instead of traefik

### DIFF
--- a/src/e2e/cypress.config.local.ts
+++ b/src/e2e/cypress.config.local.ts
@@ -4,13 +4,13 @@ import {defineConfig} from 'cypress'
 export default defineConfig({
   ...ciConfig,
   env: {
-    COOKIE_DOMAIN: 'cypress-testing-2.dev.glean.ninja',
-    ADMIN_URL: 'https://cypress-testing-2.dev.glean.ninja/admin',
-    GLEAN_URL: 'https://cypress-testing-2.dev.glean.ninja',
+    COOKIE_DOMAIN: 'nginx.dev.glean.ninja',
+    ADMIN_URL: 'https://nginx.dev.glean.ninja/admin',
+    GLEAN_URL: 'https://nginx.dev.glean.ninja',
     LOG_FAILURES_TO_KIBANA: 'false',
   },
   e2e: {
     ...ciConfig.e2e,
-    baseUrl: 'https://cypress-testing-2.dev.glean.ninja',
+    baseUrl: 'https://nginx.dev.glean.ninja',
   },
 })

--- a/src/run-glean-cypress-tests.sh
+++ b/src/run-glean-cypress-tests.sh
@@ -7,8 +7,8 @@ LOG_FAILURES_TO_KIBANA="true"
 export CHROME_LOG_FILE="chrome_debug.log"
 
 # Would normally be dynamically set for our branch builds, just hardcode for this example repo
-GLEAN_URL=https://cypress-testing-2.dev.glean.ninja
-ADMIN_URL=https://cypress-testing-2.dev.glean.ninja/admin
-COOKIE_DOMAIN=cypress-testing-2.dev.glean.ninja
+GLEAN_URL=https://nginx.dev.glean.ninja
+ADMIN_URL=https://nginx.dev.glean.ninja/admin
+COOKIE_DOMAIN=nginx.dev.glean.ninja
 
 CYPRESS_baseUrl=$GLEAN_URL cypress run --browser="chrome" --headed --project . --env COOKIE_DOMAIN="$COOKIE_DOMAIN",TEST_HELPER_USR="$TEST_HELPER_USR",TEST_HELPER_PSW="$TEST_HELPER_PSW",ADMIN_URL="$ADMIN_URL",GLEAN_URL="$GLEAN_URL",LOG_FAILURES_TO_KIBANA=$LOG_FAILURES_TO_KIBANA,DELETE_SUCCESS_VIDEOS=true --spec "./integration/ci/**/*.spec.ts"


### PR DESCRIPTION
This experiment runs against nginx.dev.glean.ninja/admin, which is using nginx rather than traefik to do the routing (but still hosted in our usual way otherwise)